### PR TITLE
Update to imagej-tensorflow 0.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
 		<license.licenseName>apache_v2</license.licenseName>
 		<license.copyrightOwners>Google, Inc. and Board of Regents of the
 University of Wisconsin-Madison.</license.copyrightOwners>
-		<!-- TODO: remove override once pom-scijava 17.0.1 is released. -->
-		<imagej-tensorflow.version>0.1.1</imagej-tensorflow.version>
+		<!-- TODO: remove override once pom-scijava 17.2.0 is released. -->
+		<imagej-tensorflow.version>0.2.0</imagej-tensorflow.version>
 
 		<!-- NB: Deploy releases to the ImageJ Maven repository. -->
 		<releaseProfiles>deploy-to-imagej</releaseProfiles>


### PR DESCRIPTION
The API changed and doesn't provide normalization anymore. We need to
normalize the image ourself now.