### PR TITLE
Partial image analysis

### DIFF
--- a/src/main/java/sc/fiji/imageFocus/Images.java
+++ b/src/main/java/sc/fiji/imageFocus/Images.java
@@ -1,0 +1,53 @@
+/*-
+ * #%L
+ * ImageJ plugin to analyze focus quality of microscope images.
+ * %%
+ * Copyright (C) 2017 Google, Inc. and Board of Regents of the
+ * University of Wisconsin-Madison.
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+package sc.fiji.imageFocus;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converter;
+import net.imglib2.converter.Converters;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Util;
+
+/**
+ * Utility methods for manipulating images.
+ *
+ * @author Curtis Rueden
+ */
+public final class Images {
+
+	private Images() {
+		// NB: Prevent instantiation of utility class.
+	}
+
+	/** Normalizes an image to {@link FloatType} in range {@code [0, 1]}. */
+	public static <T extends RealType<T>> RandomAccessibleInterval<FloatType>
+		normalize(final RandomAccessibleInterval<T> image)
+	{
+		final T sample = Util.getTypeFromInterval(image);
+		final double min = sample.getMinValue();
+		final double max = sample.getMaxValue();
+		final Converter<T, FloatType> normalizer = //
+			(in, out) -> out.setReal((in.getRealDouble() - min) / (max - min));
+		return Converters.convert(image, normalizer, new FloatType());
+	}
+}

--- a/src/main/java/sc/fiji/imageFocus/MicroscopeImageFocusQualityClassifier.java
+++ b/src/main/java/sc/fiji/imageFocus/MicroscopeImageFocusQualityClassifier.java
@@ -40,7 +40,7 @@ import net.imagej.axis.AxisType;
 import net.imagej.display.ColorTables;
 import net.imagej.tensorflow.TensorFlowService;
 import net.imagej.tensorflow.Tensors;
-import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.display.ColorTable8;
 import net.imglib2.img.Img;
@@ -48,8 +48,10 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.FloatType;
 
+import org.scijava.Initializable;
 import org.scijava.ItemIO;
 import org.scijava.command.Command;
+import org.scijava.command.Previewable;
 import org.scijava.io.http.HTTPLocation;
 import org.scijava.log.LogService;
 import org.scijava.plugin.Parameter;
@@ -80,7 +82,7 @@ import org.tensorflow.framework.TensorInfo;
 @Plugin(type = Command.class,
 	menuPath = "Plugins>Classification>Microscope Image Focus Quality")
 public class MicroscopeImageFocusQualityClassifier<T extends RealType<T>>
-	implements Command
+	implements Command, Initializable, Previewable
 {
 
 	private static final String MODEL_URL =
@@ -97,6 +99,8 @@ public class MicroscopeImageFocusQualityClassifier<T extends RealType<T>>
 	// API.
 	private static final String DEFAULT_SERVING_SIGNATURE_DEF_KEY =
 		"serving_default";
+
+	private static final int TILE_SIZE = 84;
 
 	@Parameter
 	private TensorFlowService tensorFlowService;
@@ -118,6 +122,22 @@ public class MicroscopeImageFocusQualityClassifier<T extends RealType<T>>
 	 */
 	@Parameter(required = false)
 	private ImagePlus originalImagePlus;
+
+	private Overlay originalOverlay;
+
+	@Parameter(label = "Number of tiles in X", persist = false,
+		callback = "refreshTilePreview", min = "1",
+		description = "<html>The number of tiles to process in the X direction. " +
+			"The smaller this value, the less<br>of the image will be covered " +
+			"horizontally, but the faster the processing will be.")
+	private long tileCountX = 1;
+
+	@Parameter(label = "Number of tiles in Y", persist = false,
+		callback = "refreshTilePreview", min = "1",
+		description = "<html>The number of tiles to process in the Y direction. " +
+			"The smaller this value, the less<br>of the image will be covered " +
+			"vertically, but the faster the processing will be.")
+	private long tileCountY = 1;
 
 	@Parameter(label = "Generate probability image",
 		description = "<html>When checked, a multi-channel image will be created " +
@@ -151,8 +171,10 @@ public class MicroscopeImageFocusQualityClassifier<T extends RealType<T>>
 	public void run() {
 		try {
 			validateFormat(originalImage);
+			final RandomAccessibleInterval<T> tiledImage = //
+				Images.tile(originalImage, tileCountX, tileCountY, TILE_SIZE, TILE_SIZE);
 			final RandomAccessibleInterval<FloatType> normalizedImage = //
-				Images.normalize(originalImage);
+				Images.normalize(tiledImage);
 
 			final long loadModelStart = System.nanoTime();
 			final HTTPLocation source = new HTTPLocation(MODEL_URL);
@@ -192,6 +214,53 @@ public class MicroscopeImageFocusQualityClassifier<T extends RealType<T>>
 			// Use the LogService to report the error.
 			log.error(exc);
 		}
+	}
+
+	@Override
+	public void initialize() {
+		if (originalImage == null) return;
+		tileCountX = Math.max(1, originalImage.dimension(0) / TILE_SIZE);
+		tileCountY = Math.max(1, originalImage.dimension(1) / TILE_SIZE);
+		if (originalImagePlus != null) {
+			originalOverlay = originalImagePlus.getOverlay();
+		}
+		refreshTilePreview();
+	}
+
+	@Override
+	public void preview() {
+		// NB: No action needed.
+	}
+
+	@Override
+	public void cancel() {
+		if (originalImagePlus != null && originalOverlay != null) {
+			originalImagePlus.setOverlay(originalOverlay);
+		}
+	}
+
+	/** Callback method for {@link #tileCountX} and {@link #tileCountY}. */
+	private void refreshTilePreview() {
+		if (originalImagePlus == null) return;
+
+		final int tileOpacity = 64;
+		final Color evenColor = new Color(100, 255, 255, tileOpacity);
+		final Color oddColor = new Color(255, 255, 100, tileOpacity);
+
+		final long w = originalImage.dimension(0);
+		final long h = originalImage.dimension(1);
+
+		final Overlay overlay = new Overlay();
+		for (long y = 0; y < tileCountY; y++) {
+			final long offsetY = Images.offset(y, tileCountY, TILE_SIZE, h);
+			for (long x = 0; x < tileCountX; x++) {
+				final long offsetX = Images.offset(x, tileCountX, TILE_SIZE, w);
+				final Roi tile = new Roi(offsetX, offsetY, TILE_SIZE, TILE_SIZE);
+				tile.setFillColor((x + y) % 2 == 0 ? evenColor : oddColor);
+				overlay.add(tile);
+			}
+		}
+		originalImagePlus.setOverlay(overlay);
 	}
 
 	private void validateFormat(final Img<T> image) throws IOException {
@@ -249,12 +318,9 @@ public class MicroscopeImageFocusQualityClassifier<T extends RealType<T>>
 	private void createProbabilityImage(final int classCount,
 		final float[][] probValues, final int patchHeight, final int patchWidth)
 	{
-		final int patchesInX = (int) originalImage.dimension(0) / patchWidth;
-		final int patchesInY = (int) originalImage.dimension(1) / patchHeight;
-
 		// Create probability image.
-		final long width = patchWidth * patchesInX;
-		final long height = patchHeight * patchesInY;
+		final long width = originalImage.dimension(0);
+		final long height = originalImage.dimension(1);
 		final long[] dims = { width, height, classCount };
 		final AxisType[] axes = { Axes.X, Axes.Y, Axes.CHANNEL };
 		final FloatType type = new FloatType();
@@ -267,17 +333,39 @@ public class MicroscopeImageFocusQualityClassifier<T extends RealType<T>>
 			probDataset.setColorTable(ColorTables.GRAYS, c);
 		}
 
-		// Populate the probability image's sample values.
 		final ImgPlus<FloatType> probImg = probDataset.typedImg(type);
-		final Cursor<FloatType> cursor = probImg.localizingCursor();
-		final int[] pos = new int[dims.length];
-		while (cursor.hasNext()) {
-			cursor.next();
-			cursor.localize(pos);
-			final int x = pos[0], y = pos[1], c = pos[2];
-			final int patchIndexX = x / patchWidth, patchIndexY = y / patchHeight;
-			final int p = patchesInX * patchIndexY + patchIndexX;
-			cursor.get().set(probValues[p][c]);
+
+		// Cover the probability image with NaNs.
+		// Real values will be written only to tile-covered areas.
+		for (final FloatType sample : probImg) {
+			sample.set(Float.NaN);
+		}
+
+		// Populate the probability image's sample values.
+		final RandomAccess<FloatType> access = probImg.randomAccess();
+		for (int t = 0; t < probValues.length; t++) {
+			for (int c = 0; c < probValues[t].length; c++) {
+				// Compute tile coordinates from probability value index.
+				final long tx = t % tileCountX;
+				final long ty = t / tileCountX;
+
+				// Compute offset of tile in original image.
+				final long offsetX = Images.offset(tx, tileCountX, patchWidth, width);
+				final long offsetY = Images.offset(ty, tileCountY, patchHeight, height);
+
+				// Copy the current value to every sample within the tile.
+				final float value = probValues[t][c];
+				access.setPosition(c, 2);
+				access.setPosition(offsetY, 1);
+				for (int y = 0; y < TILE_SIZE; y++) {
+					access.setPosition(offsetX, 0);
+					for (int x = 0; x < TILE_SIZE; x++) {
+						access.get().set(value);
+						access.fwd(0);
+					}
+					access.fwd(1);
+				}
+			}
 		}
 	}
 
@@ -286,7 +374,6 @@ public class MicroscopeImageFocusQualityClassifier<T extends RealType<T>>
 	{
 		final int patchCount = probValues.length;
 		final int classCount = probValues[0].length;
-		final int patchesInX = originalImagePlus.getWidth() / patchWidth;
 
 		final Overlay overlay = new Overlay();
 
@@ -294,11 +381,14 @@ public class MicroscopeImageFocusQualityClassifier<T extends RealType<T>>
 		final ColorTable8 lut = ColorTables.SPECTRUM;
 		final int lutMaxIndex = 172;
 
+		final long width = originalImage.dimension(0);
+		final long height = originalImage.dimension(1);
+
 		for (int p = 0; p < patchCount; p++) {
-			final int patchIndexX = p % patchesInX;
-			final int patchIndexY = p / patchesInX;
-			final int offsetX = patchWidth * patchIndexX + strokeWidth / 2;
-			final int offsetY = patchHeight * patchIndexY + strokeWidth / 2;
+			final long tx = p % tileCountX;
+			final long ty = p / tileCountX;
+			final long offsetX = Images.offset(tx, tileCountX, patchWidth, width) + strokeWidth / 2;
+			final long offsetY = Images.offset(ty, tileCountY, patchHeight, height) + strokeWidth / 2;
 
 			final Roi roi = new Roi(offsetX, offsetY, //
 				patchWidth - strokeWidth, patchHeight - strokeWidth);

--- a/src/main/java/sc/fiji/imageFocus/MicroscopeImageFocusQualityClassifier.java
+++ b/src/main/java/sc/fiji/imageFocus/MicroscopeImageFocusQualityClassifier.java
@@ -327,10 +327,12 @@ public class MicroscopeImageFocusQualityClassifier<T extends RealType<T>>
 		probDataset = datasetService.create(type, dims, "Probabilities", axes,
 			false);
 
-		// Set the probability image to grayscale.
+		// Set the probability image to normalized grayscale.
 		probDataset.initializeColorTables(classCount);
 		for (int c = 0; c < classCount; c++) {
 			probDataset.setColorTable(ColorTables.GRAYS, c);
+			probDataset.setChannelMinimum(c, 0);
+			probDataset.setChannelMaximum(c, 1);
 		}
 
 		final ImgPlus<FloatType> probImg = probDataset.typedImg(type);


### PR DESCRIPTION
This branch adds the ability to analyze only a subset of the image. It works by allowing the user to choose a lesser amount of tile coverage in the X and/or Y directions.

<img width="494" alt="spaced-tiles" src="https://user-images.githubusercontent.com/556626/44361598-f9000800-a483-11e8-98bf-1d826339c5b6.png">
<img width="590" alt="tiles-dialog" src="https://user-images.githubusercontent.com/556626/44361622-05846080-a484-11e8-965c-f7ece91b1360.png">

In the resultant probability image, values outside of analyzed tile boundaries are set to NaN.

This change breaks backward compatibility: there will no longer be a way to execute the analysis on the "top left" portion of an image, but only on a region with evenly spaced tiles. Here is an example demonstrating the discrepancy:

<img width="522" alt="old" src="https://user-images.githubusercontent.com/556626/44361480-99a1f800-a483-11e8-868d-a4c26d54f00e.png">
<img width="522" alt="new" src="https://user-images.githubusercontent.com/556626/44361477-973f9e00-a483-11e8-8d8e-c65494c7b195.png">
<img width="522" alt="diff" src="https://user-images.githubusercontent.com/556626/44361485-9c045200-a483-11e8-996e-b3ae618d1311.png">

@samueljyang @marktsuchida What do you think?

1. Do you like this way of distributing tiles to resolve #4?
2. Should we do something to preserve backwards compatibility? For example, we could also add explicit X and Y spacing parameters. But this would make the dialog more complex.
